### PR TITLE
Update accompanist to 0.29.0-alpha

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 androidGradlePlugin = "7.4.0"
 protoWirePlugin = "4.4.3"
 
-accompanist = "0.28.0"
+accompanist = "0.29.0-alpha"
 androidDesugarJdkLibs = "1.1.5"
 androidxActivity = "1.6.1"
 androidxAppCompat = "1.6.0"


### PR DESCRIPTION
I got this crash.

`FATAL EXCEPTION: main
java.lang.NoSuchMethodError: No virtual method snapTo(Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object; in class Landroidx/compose/material/ModalBottomSheetState; or its super classes `

Steps:
Click New List, and the bottom sheet will show, then click outside to hide the bottom sheet.
In a little while, the app crashed.

To fix it.
We need to update _accompanist_ after upgrading Compose UI.
[accompanist vs Compose versions](https://github.com/google/accompanist)